### PR TITLE
Remove redundant code in logToFile

### DIFF
--- a/commands/hello.js
+++ b/commands/hello.js
@@ -33,13 +33,6 @@ module.exports = {
 
 // Function to append messages to the newest file in the "logs" folder
 function logToFile(message) {
-  const logsFolder = './logs';
-
-  const logFiles = fs.readdirSync(logsFolder).filter(file => file.endsWith('.log'));
-  logFiles.sort((a, b) => fs.statSync(path.join(logsFolder, b)).mtime.getTime() - fs.statSync(path.join(logsFolder, a)).mtime.getTime());
-
-  const newestLogFile = logFiles.length > 0 ? logFiles[0] : new Date().toISOString().replace(/:/g, '-') + '.log';
-  const logFilePath = path.join(logsFolder, newestLogFile);
-
+  const logFilePath = path.join('./logs', new Date().toISOString().replace(/:/g, '-') + '.log');
   fs.appendFileSync(logFilePath, `${message}\n`);
 }


### PR DESCRIPTION
Pretty sure this is a bug before? else it makes even less sense